### PR TITLE
Use hash_equals() for constant-time CSRF token comparison. Replaces t…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.6.0",
         "minphp/html": "~1.0"
     },
     "require-dev": {

--- a/src/Form.php
+++ b/src/Form.php
@@ -217,7 +217,10 @@ class Form extends Html
             $csrf_token = $_POST[$this->csrf_token_name];
         }
 
-        return $this->getCsrfToken($key) == $csrf_token;
+        return hash_equals(
+            $this->getCsrfToken($key),
+            is_string($csrf_token) ? $csrf_token : ''
+        );
     }
 
     /**


### PR DESCRIPTION
…iming-vulnerable == comparison in verifyCsrfToken() with hash_equals(), and bumps the PHP requirement to >=5.6.0 to match.

CORE-5947